### PR TITLE
Listen for power characteristic updates

### DIFF
--- a/src/controls/Control.ts
+++ b/src/controls/Control.ts
@@ -8,6 +8,14 @@ export interface IAccessoryCallback {
   (err: Error, value?: number): void;
 };
 
+export interface IControlReport {
+  tokens: Array<string>;
+  source: string;
+  target: string;
+  opcode: number;
+  args: Array<number>;
+};
+
 export default class Control {
 
   name: string;

--- a/src/controls/Power.ts
+++ b/src/controls/Power.ts
@@ -1,5 +1,11 @@
 const cec = require('cec-promise');
-import Control, {IControlConfig} from './Control';
+import Control, {IControlConfig, IControlReport} from './Control';
+
+export enum PowerStatus {
+  On = 'on',
+  Standby = 'standby',
+  Unknown = 'unknown',
+};
 
 export default class PowerControl extends Control {
 
@@ -21,7 +27,11 @@ export default class PowerControl extends Control {
     });
   }
 
-  setOn(on: number, callback: (err: Error) => void) {
+  setOn(on: number, callback: (err: Error) => void, context) {
+    if (context === 'internal') {
+      callback(null);
+      return;
+    }
     this.getOn((err, isOn) => {
       if (err !== null) {
         this.log(err);
@@ -35,6 +45,22 @@ export default class PowerControl extends Control {
           cec.send(`${newMode} ${this.controlNibble}`);
         }
         callback(null);
+      }
+    });
+  }
+
+  onReportStatus(callback: (status: PowerStatus) => void) {
+    cec.on('REPORT_POWER_STATUS', (status: IControlReport) => {
+      if (Number(status.source) === this.controlNibble) {
+        const powerStatus = (() => {
+          switch (status.args[0]) {
+            case cec.code.PowerStatus.ON: return PowerStatus.On;
+            case cec.code.PowerStatus.STANDBY: return PowerStatus.Standby;
+            default: return PowerStatus.Unknown;
+          }
+        })();
+        this.log(`${this.name} reportStatus: ${powerStatus}`);
+        callback(powerStatus);
       }
     });
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 let Service, Characteristic;
 import cec = require('cec-promise');
-import PowerControl from './controls/Power';
+import PowerControl, {PowerStatus} from './controls/Power';
 import VolumeControl from './controls/Volume';
 
 interface ICecAccessoryConfig {
@@ -40,11 +40,15 @@ class CecAccessory {
         address: this.address,
         log: this.log
       });
-      let powerService = new Service.Switch(`${this.name}`);
-      powerService
-        .getCharacteristic(Characteristic.On)
+      const powerService = new Service.Switch(`${this.name}`);
+      const characteristic = powerService.getCharacteristic(Characteristic.On);
+      characteristic
         .on('get', power.getOn.bind(power))
-        .on('set', power.setOn.bind(power));
+        .on('set',power.setOn.bind(power));
+        power.onReportStatus((status: PowerStatus) => {
+          characteristic.setValue(status === PowerStatus.On, null, 'internal');
+        });
+
       return [powerService];
 
     case 'volume':


### PR DESCRIPTION
- Exposes an event handler on `PowerControl` interface that triggers on `REPORT_POWER_STATUS` events from cec-client
- Use it to update homebridge `On` characteristic value

This allows to immediately report back in HomeKit the state of the control, and partially resolves #1. (Volume control reporting not implemented)
Requires https://github.com/jbree/cec-promise/pull/2.